### PR TITLE
Add bottom margin to report otherwise for long output where vertical scroll is needed the output will be visually covered by the Jenkins footer

### DIFF
--- a/src/main/webapp/css/summary_report.css
+++ b/src/main/webapp/css/summary_report.css
@@ -5,6 +5,7 @@
 .summary_report_project {
     margin-right: 2em;
     margin-top: 5em;
+    margin-bottom: 5em;
 }
 
 .summary_report_field {


### PR DESCRIPTION

To reproduce the problem the published XML report has to be vertically quite long, as so Jenkins will create a vertically scrollable page. In this case the space allocated is calculated as barely precise to fit the contents and the Jenkins footer will therefore overwrite the last part of it. 
Just adding a spare bottom margin in the CSS solves the issue.